### PR TITLE
Use native Flux/NNlib asymmetric padding on CPU. Fix yolov2 box location & size

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ YOLO.v3_tiny_416_COCO()
 The following are available but do not load due to bugs (work in progress)
 ```julia
 YOLO.v2_608_COCO()
-YOLO.v3_608_spp_COCO()
+YOLO.v3_spp_608_COCO()
 ```
 
 Or custom models can be loaded with:

--- a/examples/scratch.jl
+++ b/examples/scratch.jl
@@ -2,6 +2,7 @@ using ObjectDetector, FileIO
 
 yolomod = YOLO.v2_tiny_416_COCO(silent=true)
 yolomod = YOLO.v3_tiny_416_COCO(silent=true)
+yolomod = YOLO.v3_spp_608_COCO(silent=true)
 
 batch = emptybatch(yolomod)
 img = load(joinpath(dirname(dirname(pathof(ObjectDetector))),"test","images","dog-cycle-car.png"))

--- a/examples/scratch.jl
+++ b/examples/scratch.jl
@@ -1,6 +1,7 @@
 using ObjectDetector, FileIO
 
-yolomod = YOLO.v3_416_COCO()
+yolomod = YOLO.v2_tiny_416_COCO(silent=true)
+yolomod = YOLO.v3_tiny_416_COCO(silent=true)
 
 batch = emptybatch(yolomod)
 img = load(joinpath(dirname(dirname(pathof(ObjectDetector))),"test","images","dog-cycle-car.png"))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,7 +59,7 @@ function benchmark(;select = [1,3,4,5,6], reverseAfter::Bool = false)
                         YOLO.v3_320_COCO,
                         YOLO.v3_416_COCO,
                         YOLO.v3_608_COCO,
-                        YOLO.v3_608_spp_COCO
+                        YOLO.v3_spp_608_COCO
                         ][select]
     reverseAfter && (pretrained_list = vcat(pretrained_list, reverse(pretrained_list)))
     IMG = rand(RGB,416,416)

--- a/src/yolo/pretrained.jl
+++ b/src/yolo/pretrained.jl
@@ -16,7 +16,7 @@ v3_416_COCO(;batch=1, silent=false) =
 v3_608_COCO(;batch=1, silent=false) =
     yolo(joinpath(models_dir,"yolov3-608.cfg"), getArtifact("yolov3-COCO"), batch, silent=silent)
 
-v3_608_spp_COCO(;batch=1, silent=false) =
+v3_spp_608_COCO(;batch=1, silent=false) =
     yolo(joinpath(models_dir,"yolov3-spp.cfg"), getArtifact("yolov3-spp-COCO"), batch, silent=silent)
 
 ## YOLOV3-tiny

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -117,6 +117,17 @@ This is only run once when weights are loaded
 flip(x) = x[end:-1:1, end:-1:1, :, :]
 
 """
+    maxpools1(x, kernel = 2)
+We need a max-pool with a fixed stride of 1
+"""
+function maxpools1(x, kernel = 2)
+    x = cat(x, x[:, end:end, :, :], dims = 2)
+    x = cat(x, x[end:end, :, :, :], dims = 1)
+    pdims = PoolDims(x, (kernel, kernel); stride = 1)
+    return maxpool(x, pdims)
+end
+
+"""
     upsample(a, stride)
 
 Optimized upsampling without indexing for better GPU performance
@@ -207,7 +218,11 @@ mutable struct yolo <: Model
             elseif blocktype == :maxpool
                 siz = block[:size]
                 stride = block[:stride]
-                push!(fn, x -> maxpool(x, PoolDims(x, (siz, siz); stride = (stride, stride), padding = (0,2-stride,0,2-stride))))
+                if stride==1 && CuFunctional
+                    push!(fn, x -> maxpools1(x, siz)) #Asymmetric padding not supported by CuDNN
+                else
+                    push!(fn, x -> maxpool(x, PoolDims(x, (siz, siz); stride = (stride, stride), padding = (0,2-stride,0,2-stride))))
+                end
                 push!(ch, ch[end])
                 !silent && prettyprint(["($(length(fn))) ","maxpool($siz,$stride)"," => "],[:blue,:magenta,:green])
             # for these layers don't push a function to fn, just note the skip-type and where to skip from

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,9 @@ pretrained_list = [
 
 IMG = load(joinpath(@__DIR__,"images","dog-cycle-car.png"))
 
+resultsdir = joinpath(@__DIR__,"results")
+!isdir(resultsdir) && mkdir(resultsdir)
+
 header = ["Model" "loaded?" "load time (s)" "ran?" "run time (s)" "objects detected"]
 table = Array{Any}(undef, length(pretrained_list), 6)
 for (i, pretrained) in pairs(pretrained_list)
@@ -39,7 +42,9 @@ for (i, pretrained) in pairs(pretrained_list)
         table[i, 6] = size(res, 2)
 
         imgBoxes = drawBoxes(IMG, res)
-        save(joinpath(@__DIR__,"results","$(modelname)_dog-cycle-car.jpg"), imgBoxes)
+        resfile = joinpath(resultsdir,"$(modelname)_dog-cycle-car.jpg")
+        save(resfile, imgBoxes)
+        @info "Bounding boxes drawn on image: $resfile"
 
         @test size(res,2) > 0
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ pretrained_list = [
                     YOLO.v3_320_COCO,
                     YOLO.v3_416_COCO,
                     YOLO.v3_608_COCO,
-                    # YOLO.v3_608_spp_COCO
+                    # YOLO.v3_spp_608_COCO
                     ]
 
 IMG = load(joinpath(@__DIR__,"images","dog-cycle-car.png"))


### PR DESCRIPTION
This works and passes tests on CPU, but unfortunately hits the following on CUDA:
```
┌ Warning: CuDNN does not support asymmetric padding; defaulting to symmetric choice
└ @ CuArrays.CUDNN ~/.julia/packages/CuArrays/GTeAW/src/dnn/pooling.jl:26
```
Although tests pass on CUDA and the resulting boxes seem only slightly worse