### PR TITLE
Fix newly erroring count call within keepdetections

### DIFF
--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -501,7 +501,7 @@ function keepdetections(input::CuArray) # THREADS:BLOCKS CAN BE OPTIMIZED WITH B
     bools = CUDA.zeros(Int32, cols)
     @cuda blocks=cols threads=rows kern_genbools(input, bools)
     idxs = cumsum(bools)
-    n = count(bools)
+    n = count(isone, bools)
     output = CuArray{Float32, 2}(undef, rows, n)
     @cuda blocks=cols threads=rows kern_keepdetections(input, output, bools, idxs)
     return output


### PR DESCRIPTION
`count(::CuArray{Int32,1})` has started erroring, perhaps in Julia 1.5, or perhaps due to a CUDA update.
Either way, it's not valid usage, and this fixes it