### PR TITLE
Make empty output type stable and have correct empty shape

### DIFF
--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -616,14 +616,9 @@ function (yolo::yolo)(img::DenseArray; detectThresh=nothing, overlapThresh=yolo.
     # PROCESSING ALL PREDICTIONS
     ############################
 
-    batchout = cpu(keepdetections(cat(outweights..., dims=2)))
-    if size(batchout, 1) == 0
-        if CU_FUNCTIONAL[]
-            return CUDA.zeros(Float32, 1, 1)
-        else
-            return zeros(Float32, 1, 1)
-        end
-    end
+    batchout = cpu(keepdetections(cat(outweights..., dims=2)))::Matrix{Float32}
+
+    size(batchout, 2) < 2 && return batchout # empty or singular output doesn't need further filtering
 
     classes = unique(batchout[end-1, :])
     output = Array{Float32, 2}[]
@@ -640,7 +635,7 @@ function (yolo::yolo)(img::DenseArray; detectThresh=nothing, overlapThresh=yolo.
             push!(output, detection)
         end
     end
-    return hcat(output...)
+    return hcat(output...)::Matrix{Float32}
 end
 
 include(joinpath(@__DIR__,"pretrained.jl"))


### PR DESCRIPTION
The output when no detections were made was unnecessarily type unstable, returning a CUDA array if GPU enabled, and for no real reason resolved to a different empty array size.
Given that the end filtering always happens on cpu, this can be simplified to always return `Matrix{Float32}` with the correct dim 1 size based on the model class count + standard params.

On a CPU-only machine

## Master

No detections
```julia
julia> yolomod(batch, detectThresh=0.5, overlapThresh=0.8)
Any[]
```
1 detection
```julia
julia> yolomod(batch, detectThresh=0.5, overlapThresh=0.8)
89×1 Matrix{Float32}
```

## This PR
No detections
```julia
julia> yolomod(batch, detectThresh=0.5, overlapThresh=0.8)
89×0 Matrix{Float32}
```
1 detection
```julia
julia> yolomod(batch, detectThresh=0.5, overlapThresh=0.8)
89×1 Matrix{Float32}
```


