### PR TITLE
Fix Flux BatchNorm deprecation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 
 [compat]
 BenchmarkTools = "0.4, 0.5, 0.6"
-Flux = "0.11, 0.12"
+Flux = "0.12"
 ImageCore = "0.8"
 ImageDraw = "0.2"
 ImageFiltering = "0.6"

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -247,7 +247,7 @@ mutable struct yolo <: AbstractModel
                 bn      = haskey(block, :batch_normalize)
                 cw, cb, bb, bw, bm, bv = readweights(weightbytes, kern, ch[end], filters, bn)
                 push!(stack, gpu(Conv(cw, cb; stride = stride, pad = pad, dilation = 1)))
-                bn && push!(stack, gpu(BatchNorm(identity, bb, bw, bm, bv, 1f-5, 0.1f0, nothing)))
+                bn && push!(stack, gpu(BatchNorm(identity, bb, bw, bm, bv, 1f-5, 0.1f0, true, true, nothing, length(bb))))
                 push!(stack, let; _act(x) = act.(x) end)
                 push!(fn, Chain(stack...))
                 push!(ch, filters)


### PR DESCRIPTION
Fixes deprecation warning in Flux 0.12
```
┌ Warning: `BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, active = nothing)` is deprecated, use `BatchNorm(λ, β, γ, μ, σ², ϵ, momentum, true, true, active, length(β))` instead.
│   caller = ip:0x0
└ @ Core :-1
```