### PR TITLE
Fix minor testing path bug

### DIFF
--- a/.github/workflows/RunTests.yml
+++ b/.github/workflows/RunTests.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/julia-runtest@master
+        with:
+          coverage: false
       # - uses: julia-actions/julia-processcoverage@v1
       # - uses: codecov/codecov-action@v1
       #   with:

--- a/test/maintests.jl
+++ b/test/maintests.jl
@@ -79,7 +79,7 @@ for (k, pretrained) in pairs(pretrained_list)
             @info """Testing image "$imagename" """
             IMG = load(joinpath(@__DIR__,"images","$imagename.png"))
             resultsdir = joinpath(@__DIR__,"results",imagename)
-            !isdir(resultsdir) && mkdir(resultsdir)
+            mkpath(resultsdir)
             batch[:,:,:,1], padding = prepareImage(IMG, yolomod)
 
             val, t_run, bytes, gctime, m = @timed res = yolomod(batch, detectThresh=dThresh, overlapThresh=oThresh);


### PR DESCRIPTION
This fixes
```
Errors encountered while save File{DataFormat{:PNG}, String}("/home/ian/.julia/packages/ObjectDetector/sX9Lc/test/results/dog-cycle-car_nonsquare/v2_tiny_416_COCO.png").
All errors:
===========================================
Could not open /home/ian/.julia/packages/ObjectDetector/sX9Lc/test/results/dog-cycle-car_nonsquare/v2_tiny_416_COCO.png for writing
===========================================
ArgumentError: Package ImageMagick [6218d12a-5da1-5696-b52f-db25d2ecc6d1] is required but does not seem to be installed:
 - Run `Pkg.instantiate()` to install all recorded dependencies.

===========================================
ArgumentError: Argument does not support conversion to png.
===========================================

Fatal error:
Pretrained Model: v2_tiny_416_COCO: Error During Test at /home/ian/.julia/packages/ObjectDetector/sX9Lc/test/maintests.jl:66
  Got exception outside of a @test
  Could not open /home/ian/.julia/packages/ObjectDetector/sX9Lc/test/results/dog-cycle-car_nonsquare/v2_tiny_416_COCO.png for writing
  Stacktrace:
```
