### PR TITLE
improve efficiency of nms step

### DIFF
--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -547,22 +547,113 @@ function (yolo::yolo)(img::DenseArray; detectThresh=nothing, overlapThresh=yolo.
 
     size(batchout, 2) < 2 && return batchout # empty or singular output doesn't need further filtering
 
-    classes = unique(batchout[end-1, :])
-    output = Array{Float32, 2}[]
-    @views for b in 1:yolo.cfg[:batchsize]
-        page = batchout[:, batchout[end,:] .== b]
-        for c in classes
-            detection = sortslices(page[:, page[end-1, :] .== c], dims = 2, by = x -> x[5], rev = true)
-            for det_idx in 1:size(detection, 2)
-                iou = bboxiou(detection[1:4, det_idx], detection[1:4, det_idx+1:end])
-                same_objects = findall(>=(overlapThresh), iou)
-                detection = detection[:, setdiff(1:size(detection, 2), same_objects .+ det_idx)]
-                det_idx >= size(detection,2) && break
+    batchsize = yolo.cfg[:batchsize]
+
+    output = perform_detection_nms(batchout, overlapThresh, batchsize)
+
+    return hcat(output...)::Matrix{Float32}
+end
+
+"""
+    nms(dets, iou_thresh)
+
+Perform a simple Non-Maximum Suppression (NMS) on the detections `dets`.
+`dets` is a 2D array of shape (≥5, N), assumed to be sorted in descending
+order by the 5th column (i.e., confidence or score). `iou_thresh` is
+the overlap threshold above which boxes are considered duplicates.
+
+Returns an array of indexes `keep` of the columns in `dets` you want to keep.
+"""
+function nms(dets::Matrix{Float32}, iou_thresh)
+    # We'll assume the bounding box coords are in dets[1:4, :].
+    # The columns are sorted by score already (descending).
+    idxs = collect(1:size(dets, 2))        # candidate column indexes
+    keep = Int[]                            # final picks
+
+    while !isempty(idxs)
+        # Pick the top-scoring box (first in the sorted list)
+        i = first(idxs)
+        push!(keep, i)
+
+        # If there's only one left, no need to compute IoU
+        if length(idxs) == 1
+            break
+        end
+
+        # Compute IoU of the chosen box with the rest
+        # - bboxiou should accept two bounding boxes or a box vs many boxes
+        #   so it returns a vector of IoUs in this usage.
+        iou = bboxiou(dets[1:4, i], dets[1:4, idxs[2:end]])
+
+        # Find which have IoU >= threshold
+        to_remove = findall(≥(iou_thresh), iou)
+
+        # Those indexes in `to_remove` are offset by +1 in the `idxs` array
+        remove_idxs = idxs[to_remove .+ 1]
+
+        # Remove them all from `idxs`
+        filter!(x -> x ∉ remove_idxs, idxs)
+
+        # Also remove the “picked” box (we already kept i)
+        filter!(x -> x != i, idxs)
+    end
+
+    return keep
+end
+
+"""
+    perform_detection_nms(batchout, overlapThresh, batchsize)
+
+For each batch `b` in `1:batchsize`, extract the detections from `batchout`,
+group them by class, sort each group by the 5th column (score) descending, and
+run NMS to remove duplicates.
+
+Returns a Vector of detection matrices, each of size (num_fields, kept_boxes).
+"""
+function perform_detection_nms(
+    batchout::Matrix{Float32},
+    overlapThresh,
+    batchsize::Int
+)
+    # We assume:
+    #  - batchout’s last row (end) has the batch index
+    #  - batchout’s second-to-last row (end-1) has the class index
+    #  - detection boxes: det[1:4, i] is the bounding box
+    #  - det[5, i] is the confidence/score
+    # Adjust as needed for your layout.
+
+    output = Matrix{Float32}[]  # array of matrices
+
+    @views for b in 1:batchsize
+        # Get columns that belong to batch b
+        b_idxs = findall(x -> x == b, batchout[end, :])
+        if isempty(b_idxs)
+            continue
+        end
+        page = batchout[:, b_idxs]
+
+        # For each class present in this batch
+        present_classes = unique(page[end-1, :])
+        for c in present_classes
+            # Gather all detections that match class c
+            c_idxs = findall(x -> x == c, page[end-1, :])
+            if isempty(c_idxs)
+                continue
             end
-            push!(output, detection)
+
+            # Extract and sort by confidence (the 5th row),
+            # descending:
+            dets = sortslices(page[:, c_idxs], dims=2, by = x -> x[5], rev = true)
+
+            # Run NMS to get the indexes of the columns to keep
+            keep = nms(dets, overlapThresh)
+
+            # Save the filtered detections
+            push!(output, dets[:, keep])
         end
     end
-    return hcat(output...)::Matrix{Float32}
+
+    return output
 end
 
 include(joinpath(@__DIR__,"pretrained.jl"))

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -565,7 +565,7 @@ the overlap threshold above which boxes are considered duplicates.
 Returns an array of indexes `keep` of the columns in `dets` you want to keep.
 """
 function nms(dets::Matrix{Float32}, iou_thresh)
-    # We'll assume the bounding box coords are in dets[1:4, :].
+    # The bounding box coords are in dets[1:4, :].
     # The columns are sorted by score already (descending).
     idxs = collect(1:size(dets, 2))        # candidate column indexes
     keep = Int[]                            # final picks
@@ -615,12 +615,10 @@ function perform_detection_nms(
     overlapThresh,
     batchsize::Int
 )
-    # We assume:
     #  - batchout’s last row (end) has the batch index
     #  - batchout’s second-to-last row (end-1) has the class index
     #  - detection boxes: det[1:4, i] is the bounding box
     #  - det[5, i] is the confidence/score
-    # Adjust as needed for your layout.
 
     output = Matrix{Float32}[]  # array of matrices
 


### PR DESCRIPTION
This PR
```
% julia +1.10 --project
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.7 (2024-11-26)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using ObjectDetector, Chairmarks

julia> @time yolomod = YOLO.v3_COCO(dummy=true, silent=true, use_gpu=false);
  0.988061 seconds (623.22 k allocations: 1.528 GiB, 41.03% gc time, 4.06% compilation time)

julia> @time batch = emptybatch(yolomod);
  0.000048 seconds (19 allocations: 1.981 MiB)

julia> @b yolomod(batch)
1.276 s (276373 allocs: 4.675 GiB, 12.96% gc time, 0.49% compile time, without a warmup)
```
Master
```
% julia +1.10 --project
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.10.7 (2024-11-26)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> using ObjectDetector, Chairmarks

julia> @time yolomod = YOLO.v3_COCO(dummy=true, silent=true, use_gpu=false);
  0.919699 seconds (623.22 k allocations: 1.528 GiB, 38.43% gc time, 4.43% compilation time)

julia> @time batch = emptybatch(yolomod);
  0.000359 seconds (19 allocations: 1.981 MiB)

julia> @b yolomod(batch)
5.689 s (661730 allocs: 11.158 GiB, 6.07% gc time, 0.14% compile time, without a warmup)
```

I've also confirmed with downstream testing that this gives identical results for a given image with multiple classes and objects.