### PR TITLE
Fix undefined behavior in nms causing inconsistent results

### DIFF
--- a/src/yolo/nms.jl
+++ b/src/yolo/nms.jl
@@ -62,7 +62,8 @@ function nms(dets::AbstractArray, iou_thresh)
 
         # Compute IoUs between i and rest
         b2_len = idx_len - 1
-        bboxiou!(ious[1:b2_len], view(dets, 1:4, i), view(dets, 1:4, idxs[2:idx_len]))
+        # we must take a view into ious because bboxiou! writes into it
+        bboxiou!(view(ious, 1:b2_len), view(dets, 1:4, i), view(dets, 1:4, idxs[2:idx_len]))
 
         # Compress idxs in-place: keep only boxes with IoU < threshold
         write_idx = 1  # we'll overwrite idxs[2:end] starting at idxs[1]


### PR DESCRIPTION
with this PR:

```julia
julia> using TestEnv; TestEnv.activate()
"/tmp/jl_K5N2Mx/Project.toml"

julia> using ObjectDetector, FileIO
Precompiling ObjectDetector finished.
  1 dependency successfully precompiled in 22 seconds. 215 already precompiled.

julia> yolomod = YOLO.v3_608_COCO(batch=1, silent=true, disallow_bumper=false);

julia> IMG = load("test/images/dog-cycle-car.png");

julia> batch = emptybatch(yolomod);

julia> batch[:, :, :, 1], padding = prepare_image(IMG, yolomod);

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  3.017668 seconds (5.83 M allocations: 362.628 MiB, 1.35% gc time, 69.51% compilation time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  1.115737 seconds (186.89 k allocations: 12.716 MiB, 17.47% compilation time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.623343 seconds (6.60 k allocations: 513.734 KiB)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.633087 seconds (6.60 k allocations: 513.734 KiB)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.631258 seconds (6.60 k allocations: 513.734 KiB)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.666065 seconds (6.60 k allocations: 513.734 KiB)
40.35504f0

julia> yolomod = YOLO.v3_608_COCO(batch=1, silent=true, disallow_bumper=true);

julia> batch = emptybatch(yolomod);

julia> batch[:, :, :, 1], padding = prepare_image(IMG, yolomod);

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  2.773534 seconds (3.32 M allocations: 7.550 GiB, 1.48% gc time, 71.29% compilation time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.671387 seconds (4.47 k allocations: 7.335 GiB, 5.89% gc time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.637142 seconds (4.47 k allocations: 7.335 GiB, 2.07% gc time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.714057 seconds (4.47 k allocations: 7.335 GiB, 1.92% gc time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.706408 seconds (4.47 k allocations: 7.335 GiB, 2.30% gc time)
40.35504f0

julia> @time sum(yolomod(batch, detectThresh=0.5, overlapThresh=0.5))
  0.732000 seconds (4.47 k allocations: 7.335 GiB, 2.12% gc time)
40.35504f0

julia> versioninfo()
Julia Version 1.10.8
Commit 4c16ff44be8 (2025-01-22 10:06 UTC)
Build Info:
  Official https://julialang.org/ release
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 32 × 13th Gen Intel(R) Core(TM) i9-13900K
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-15.0.7 (ORCJIT, goldmont)
Threads: 4 default, 1 interactive, 2 GC (on 32 virtual cores)
```