### PR TITLE
speed up post-processing

### DIFF
--- a/src/allocators.jl
+++ b/src/allocators.jl
@@ -1,8 +1,8 @@
 struct AllocWrappedModel
     model::AbstractModel
-    allocator
+    allocator::AllocArrays.Allocator
     T
-    model_aa
+    model_aa::AbstractModel
 end
 function Base.show(io::IO, wm::AllocWrappedModel)
     println(io, "AllocWrappedModel")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -102,9 +102,9 @@ function benchmark(;select = [1,3,4,5,6], reverseAfter::Bool = false, img = rand
         batch = emptybatch(mod)
         batch[:,:,:,1], padding = prepare_image(img, mod)
 
-        res = mod(batch) #run once
-        t_run = @belapsed $mod($batch);
-        t_allocs = @allocated mod(batch)
+        res = mod(batch; detectThresh=0.0, overlapThresh=1.0) #run once
+        t_run = @belapsed $mod($batch; detectThresh=0.0, overlapThresh=1.0);
+        t_allocs = @allocated mod(batch; detectThresh=0.0, overlapThresh=1.0)
         table[i, 4] = size(res, 2)
         table[i, 5] = round(t_run, digits=4)
         table[i, 6] = round(1/t_run, digits=1)

--- a/src/yolo/nms.jl
+++ b/src/yolo/nms.jl
@@ -119,7 +119,7 @@ function perform_detection_nms(batchout, overlapThresh, batchsize::Int)
 
         seen_classes = Set{eltype(class_ids)}()
 
-        @inbounds for (local_col_idx, cls) in enumerate(class_ids)
+        for (local_col_idx, cls) in enumerate(class_ids)
             if cls in seen_classes
                 continue
             end
@@ -134,7 +134,8 @@ function perform_detection_nms(batchout, overlapThresh, batchsize::Int)
 
             scores = @view dets[5, :]
             sorted_idx = sortperm(scores, rev=true)
-            sorted_dets = dets[:, sorted_idx]  # copy, not @view!
+            # nms takes views of sorted_dets and copying here results in lower allocs and faster nms
+            sorted_dets = dets[:, sorted_idx]
 
             keep = nms(sorted_dets, overlapThresh)
 

--- a/src/yolo/nms.jl
+++ b/src/yolo/nms.jl
@@ -1,21 +1,37 @@
 """
-    bboxiou(box1, box2)
+    bboxiou!(out, box1, box2)
 
-Bounding Box Intersection Over Union - removes overlapping boxes for same object
+Compute the Intersection over Union (IoU) between a single bounding box `box1`
+and multiple boxes `box2`, writing results into `out`.
+
+- `box1`: A 4-element vector `[x1, y1, x2, y2]`
+- `box2`: A 4×N matrix, where each column is a bounding box.
+- `out`: A preallocated vector of length N to hold IoU results.
+
+This version avoids allocations by reusing `out`.
 """
-function bboxiou(box1, box2)
+function bboxiou!(out, box1, box2)
     b1x1, b1y1, b1x2, b1y2 = box1
-    b2x1, b2y1, b2x2, b2y2 = view(box2, 1, :), view(box2, 2, :), view(box2, 3, :), view(box2, 4, :)
-    rectx1 = max.(b1x1, b2x1)
-    recty1 = max.(b1y1, b2y1)
-    rectx2 = min.(b1x2, b2x2)
-    recty2 = min.(b1y2, b2y2)
-    z = zeros(length(rectx2))
-    interarea = max.(rectx2 .- rectx1, z) .* max.(recty2 .- recty1, z)
     b1area = (b1x2 - b1x1) * (b1y2 - b1y1)
-    b2area = (b2x2 .- b2x1) .* (b2y2 .- b2y1)
-    iou = interarea ./ (b1area .+ b2area .- interarea)
-    return iou
+
+    @inbounds for i in eachindex(out)
+        b2x1 = box2[1, i]
+        b2y1 = box2[2, i]
+        b2x2 = box2[3, i]
+        b2y2 = box2[4, i]
+
+        rectx1 = max(b1x1, b2x1)
+        recty1 = max(b1y1, b2y1)
+        rectx2 = min(b1x2, b2x2)
+        recty2 = min(b1y2, b2y2)
+
+        w = max(0f0, rectx2 - rectx1)
+        h = max(0f0, recty2 - recty1)
+        inter = w * h
+        b2area = (b2x2 - b2x1) * (b2y2 - b2y1)
+        out[i] = inter / (b1area + b2area - inter)
+    end
+    return out
 end
 
 """
@@ -28,38 +44,42 @@ the overlap threshold above which boxes are considered duplicates.
 
 Returns an array of indexes `keep` of the columns in `dets` you want to keep.
 """
-function nms(dets::AbstractArray, iou_thresh)
-    # The bounding box coords are in dets[1:4, :].
-    # The columns are sorted by score already (descending).
-    idxs = collect(1:size(dets, 2))        # candidate column indexes
-    keep = Int[]                            # final picks
+function nms(dets::AbstractArray{T}, iou_thresh) where T
+    N = size(dets, 2)
+    idxs = similar(dets, Int, N)
+    @inbounds for j in 1:N
+        idxs[j] = j
+    end
 
-    while !isempty(idxs)
-        # Pick the top-scoring box (first in the sorted list)
-        i = first(idxs)
+    keep = Vector{Int}()
+    ious = similar(dets, T, N) # large enough to reuse
+
+    idx_len = N
+    while idx_len > 0
+        i = idxs[1]
         push!(keep, i)
 
-        # If there's only one left, no need to compute IoU
-        if length(idxs) == 1
+        if idx_len == 1
             break
         end
 
-        # Compute IoU of the chosen box with the rest
-        # - bboxiou should accept two bounding boxes or a box vs many boxes
-        #   so it returns a vector of IoUs in this usage.
-        iou = bboxiou(dets[1:4, i], dets[1:4, idxs[2:end]])
+        # Compute IoUs between the top candidate and the rest
+        b2_len = idx_len - 1
+        b1 = @view dets[1:4, i]
+        b2s = @view dets[1:4, idxs[2:idx_len]]
+        # we must take a view into ious because bboxiou! writes into it
+        bboxiou!(view(ious, 1:b2_len), b1, b2s)
 
-        # Find which have IoU >= threshold
-        to_remove = findall(≥(iou_thresh), iou)
+        # Build new candidate list, excluding boxes with IoU >= threshold
+        write_idx = 0
+        for j in 1:b2_len
+            if ious[j] < iou_thresh
+                write_idx += 1
+                idxs[write_idx] = idxs[j+1]
+            end
+        end
 
-        # Those indexes in `to_remove` are offset by +1 in the `idxs` array
-        remove_idxs = idxs[to_remove .+ 1]
-
-        # Remove them all from `idxs`
-        filter!(x -> x ∉ remove_idxs, idxs)
-
-        # Also remove the “picked” box (we already kept i)
-        filter!(x -> x != i, idxs)
+        idx_len = write_idx
     end
 
     return keep
@@ -84,41 +104,47 @@ batchout rows:
 - second-to-last row (end-1) has the class index.
 - The last row is the batch index
 """
-function perform_detection_nms(
-    batchout,
-    overlapThresh,
-    batchsize::Int
-)
-    output = []  # array of matrices
+function perform_detection_nms(batchout, overlapThresh, batchsize::Int)
+    output = similar(batchout)
+    i = 1  # index for writing into `output`
 
-    @views for b in 1:batchsize
-        # Get columns that belong to batch b
-        b_idxs = findall(x -> x == b, batchout[end, :])
-        if isempty(b_idxs)
+    for b in 1:batchsize
+        b_cols = findall(==(b), @view(batchout[end, :]))
+        if isempty(b_cols)
             continue
         end
-        page = batchout[:, b_idxs]
 
-        # For each class present in this batch
-        present_classes = unique(page[end-1, :])
-        for c in present_classes
-            # Gather all detections that match class c
-            c_idxs = findall(x -> x == c, page[end-1, :])
+        page = @view batchout[:, b_cols]
+        class_ids = @view page[end-1, :]
+
+        seen_classes = Set{eltype(class_ids)}()
+
+        @inbounds for (local_col_idx, cls) in enumerate(class_ids)
+            if cls in seen_classes
+                continue
+            end
+            push!(seen_classes, cls)
+
+            c_idxs = findall(==(cls), class_ids)
             if isempty(c_idxs)
                 continue
             end
 
-            # Extract and sort by confidence (the 5th row),
-            # descending:
-            dets = sortslices(page[:, c_idxs], dims=2, by = x -> x[5], rev = true)
+            dets = @view page[:, c_idxs]
 
-            # Run NMS to get the indexes of the columns to keep
-            keep = nms(dets, overlapThresh)
+            scores = @view dets[5, :]
+            sorted_idx = sortperm(scores, rev=true)
+            sorted_dets = dets[:, sorted_idx]  # copy, not @view!
 
-            # Save the filtered detections
-            push!(output, dets[:, keep])
+            keep = nms(sorted_dets, overlapThresh)
+
+            # @info "Batch $b, class $cls: input=$(size(sorted_dets, 2)), kept=$(length(keep))"
+
+            @inbounds for k in keep
+                output[:, i] = sorted_dets[:, k]
+                i += 1
+            end
         end
     end
-
-    return output
+    return output[:, 1:i-1]
 end

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -522,7 +522,7 @@ function (yolo::Yolo)(img::T; detectThresh=nothing, overlapThresh=yolo.out[1][:i
         @timeit to "forward pass" for i in eachindex(yolo.chain) # each chain writes to a predefined output
             @timeit to "layer $i" begin
                 f = yolo.chain[i]
-                out = f(yolo.W[i-1])
+                out = f(yolo.W[i-1]::T)
                 check_w_type(yolo.W[i])
                 yolo.W[i] .= out
             end
@@ -587,13 +587,12 @@ function (yolo::Yolo)(img::T; detectThresh=nothing, overlapThresh=yolo.out[1][:i
             else
                 batchsize = yolo.cfg[:batchsize]
                 @timeit to "nms" if profile
-                    Profile.Allocs.clear()
-                    Profile.Allocs.@profile sample_rate=1.0 output = perform_detection_nms(batchout, overlapThresh, batchsize)
-                    Profile.Allocs.print()
+                    Profile.clear()
+                    Profile.@profile ret = perform_detection_nms(batchout, overlapThresh, batchsize)
+                    Profile.print(noisefloor=2.0)
                 else
-                    output = perform_detection_nms(batchout, overlapThresh, batchsize)
+                    ret = perform_detection_nms(batchout, overlapThresh, batchsize)
                 end
-                ret = hcat(output...)
             end
         end
     end


### PR DESCRIPTION
Also max out detections during benchmarking to stress test that part

Before speedup
```
┌──────────────────┬─────────┬───────────────┬──────────┬──────────────┬────────────────┬─────────────┐
│            Model │ loaded? │ load time (s) │ #results │ run time (s) │ run time (fps) │ allocations │
├──────────────────┼─────────┼───────────────┼──────────┼──────────────┼────────────────┼─────────────┤
│ v2_tiny_416_COCO │    true │         2.701 │      845 │       0.0501 │           19.9 │   3.331 MiB │
│ v3_tiny_416_COCO │    true │         0.375 │     2535 │       0.0674 │           14.8 │  16.641 MiB │
│      v3_320_COCO │    true │         1.424 │     6300 │       0.3057 │            3.3 │  64.624 MiB │
│      v3_416_COCO │    true │         0.896 │    10647 │       0.5563 │            1.8 │ 177.833 MiB │
│      v3_608_COCO │    true │         1.445 │    22743 │       2.1043 │            0.5 │   1.222 GiB │
└──────────────────┴─────────┴───────────────┴──────────┴──────────────┴────────────────┴─────────────┘
```

After speedup
```
┌──────────────────┬─────────┬───────────────┬──────────┬──────────────┬────────────────┬─────────────┐
│            Model │ loaded? │ load time (s) │ #results │ run time (s) │ run time (fps) │ allocations │
├──────────────────┼─────────┼───────────────┼──────────┼──────────────┼────────────────┼─────────────┤
│ v2_tiny_416_COCO │    true │         2.734 │      845 │       0.0442 │           22.6 │ 697.438 KiB │
│ v3_tiny_416_COCO │    true │         0.385 │     2535 │       0.0476 │           21.0 │   1.903 MiB │
│      v3_320_COCO │    true │         1.501 │     6300 │       0.2582 │            3.9 │   4.844 MiB │
│      v3_416_COCO │    true │         0.788 │    10647 │       0.4195 │            2.4 │   7.849 MiB │
│      v3_608_COCO │    true │         1.345 │    22743 │       1.0851 │            0.9 │  16.347 MiB │
└──────────────────┴─────────┴───────────────┴──────────┴──────────────┴────────────────┴─────────────┘
```

```
julia> @time size(yolomod(batch, detectThresh=0.0, overlapThresh=1.0, show_timing=true))
───────────────────────────────────────────────────────────────────────────────────
                                          Time                    Allocations
                                 ───────────────────────   ────────────────────────
        Tot / % measured:             857ms / 100.0%           8.65MiB / 100.0%

Section                  ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────
yolo                          1    857ms  100.0%   857ms   8.65MiB  100.0%  8.65MiB
  forward pass                1    712ms   83.1%   712ms    410KiB    4.6%   410KiB
    layer 1                   1   81.4ms    9.5%  81.4ms   5.56KiB    0.1%  5.56KiB
    layer 2                   1   73.4ms    8.6%  73.4ms   9.22KiB    0.1%  9.22KiB
    layer 3                   1   30.1ms    3.5%  30.1ms   6.53KiB    0.1%  6.53KiB
    layer 4                   1   46.0ms    5.4%  46.0ms   11.0KiB    0.1%  11.0KiB
    layer 5                   1   18.5ms    2.2%  18.5ms   8.09KiB    0.1%  8.09KiB
    layer 6                   1   18.9ms    2.2%  18.9ms   8.09KiB    0.1%  8.09KiB
    layer 7                   1   24.2ms    2.8%  24.2ms   8.09KiB    0.1%  8.09KiB
    layer 8                   1   18.4ms    2.1%  18.4ms   8.09KiB    0.1%  8.09KiB
    layer 9                   1   17.9ms    2.1%  17.9ms   8.09KiB    0.1%  8.09KiB
    layer 10                  1   18.0ms    2.1%  18.0ms   8.09KiB    0.1%  8.09KiB
    layer 11                  1   18.1ms    2.1%  18.1ms   8.09KiB    0.1%  8.09KiB
    layer 12                  1   18.3ms    2.1%  18.3ms   8.09KiB    0.1%  8.09KiB
    layer 13                  1   11.6ms    1.4%  11.6ms   6.38KiB    0.1%  6.38KiB
    layer 14                  1   13.7ms    1.6%  13.7ms   11.1KiB    0.1%  11.1KiB
    layer 15                  1   13.4ms    1.6%  13.4ms   11.1KiB    0.1%  11.1KiB
    layer 16                  1   13.5ms    1.6%  13.5ms   11.1KiB    0.1%  11.1KiB
    layer 17                  1   13.3ms    1.6%  13.3ms   11.1KiB    0.1%  11.1KiB
    layer 18                  1   13.7ms    1.6%  13.7ms   11.1KiB    0.1%  11.1KiB
    layer 19                  1   13.5ms    1.6%  13.5ms   11.1KiB    0.1%  11.1KiB
    layer 20                  1   13.3ms    1.5%  13.3ms   11.1KiB    0.1%  11.1KiB
    layer 21                  1   13.2ms    1.5%  13.2ms   11.1KiB    0.1%  11.1KiB
    layer 22                  1   12.2ms    1.4%  12.2ms   10.4KiB    0.1%  10.4KiB
    layer 23                  1   14.0ms    1.6%  14.0ms   17.0KiB    0.2%  17.0KiB
    layer 24                  1   14.2ms    1.7%  14.2ms   17.0KiB    0.2%  17.0KiB
    layer 25                  1   14.0ms    1.6%  14.0ms   17.0KiB    0.2%  17.0KiB
    layer 26                  1   41.1ms    4.8%  41.1ms   57.2KiB    0.6%  57.2KiB
    layer 27                  1   13.2ms    1.5%  13.2ms   11.7KiB    0.1%  11.7KiB
    layer 28                  1   27.8ms    3.2%  27.8ms   32.6KiB    0.4%  32.6KiB
    layer 29                  1   13.4ms    1.6%  13.4ms   7.72KiB    0.1%  7.72KiB
    layer 30                  1   59.6ms    6.9%  59.6ms   30.3KiB    0.3%  30.3KiB
  post-processing             1    145ms   16.9%   145ms   8.25MiB   95.4%  8.25MiB
    processing outputs        1   22.7ms    2.6%  22.7ms   73.1KiB    0.8%  73.1KiB
    filter detections         1   3.14ms    0.4%  3.14ms   3.23KiB    0.0%  3.23KiB
    nms                       1    119ms   13.9%   119ms   8.17MiB   94.5%  8.17MiB
───────────────────────────────────────────────────────────────────────────────────
  0.934027 seconds (238.41 k allocations: 16.503 MiB)
(89, 22743)
```