### PR TITLE
Optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Performance
+- Post-processing is significantly cheaper when many detections are kept. For `v3_416_COCO`
+  with all 10647 candidates retained (CPU, `detect_thresh=0`), post-processing allocations
+  drop from 78 MiB to 23 MiB and NMS time by ~20%: detections are grouped for NMS with one
+  global sort instead of per-batch/per-class scans, the NMS inner loop no longer allocates
+  per suppression round, output blocks are flattened with a single allocation, and the
+  per-head transforms run as fused in-place broadcasts.
+- NMS output columns are now ordered by batch, then ascending class id, then descending
+  score (classes were previously in first-appearance order).
+
 ### Bugfixes
 - Fix the reorg (passthrough) layer and the batchnorm read order for pre-0.2 darknet weight
   headers, and apply softmax (not sigmoid) to region-layer class scores when the cfg enables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Performance
+- Batchnorm is now folded into the conv weights at load time (as darknet's
+  `fuse_conv_batchnorm` does), removing the BatchNorm pass entirely: ~4-9% faster forward
+  pass on CPU depending on the model. Outputs shift only by float rounding (< 1e-6).
 - Post-processing is significantly cheaper when many detections are kept. For `v3_416_COCO`
   with all 10647 candidates retained (CPU, `detect_thresh=0`), post-processing allocations
   drop from 78 MiB to 23 MiB and NMS time by ~20%: detections are grouped for NMS with one

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Also, non-square models can be loaded, but care should be taken to ensure that e
 dimension is an integer multiple of the filter size of the first conv layer (typically 16 or 32).
 
 
+### CPU performance tips
+
+The forward pass on CPU is dominated by BLAS matrix multiplies, so the BLAS
+backend matters more than anything else:
+
+- **Apple silicon**: load [AppleAccelerate.jl](https://github.com/JuliaLinearAlgebra/AppleAccelerate.jl)
+  before running. Apple's AMX-backed sgemm is substantially faster than the
+  default OpenBLAS (~35% faster end-to-end for `v3_416_COCO` on an M2 Pro):
+  ```julia
+  using AppleAccelerate, ObjectDetector
+  ```
+- **Intel CPUs**: [MKL.jl](https://github.com/JuliaLinearAlgebra/MKL.jl) typically
+  plays the same role.
+- BLAS threading (not Julia's `-t`) controls conv parallelism; the default
+  thread count is usually right, but `LinearAlgebra.BLAS.set_num_threads`
+  is the knob if you need to tune it.
+- For throughput, prefer batching images (`YOLO.v3_416_COCO(batch=N)`) over
+  repeated single-image calls: larger batches use the hardware more efficiently.
+
 ### CPU allocations management
 
 On CPU an `AllocArrays` & `Adapt` - based allocator is used to reduce allocations.

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -2,7 +2,7 @@ module CUDAExt
 
 using CUDA
 import Flux
-import ObjectDetector.YOLO: maxpool, clipdetect!, findmax!, keepdetections, extend_for_attributes, upsample
+import ObjectDetector.YOLO: maxpool, clipdetect!, findmax!, keepdetections, extend_for_attributes, upsample, fast_scalar_indexing
 
 const CU_FUNCTIONAL = Ref{Bool}()
 
@@ -104,6 +104,10 @@ end
 function extend_for_attributes(weights::CuArray, w, h, bo, ba)
     return cat(weights, CUDA.zeros(Float32, w, h, 4, bo, ba), dims = 3)
 end
+
+# scalar-indexing loops are not viable on device arrays; generic code paths
+# gated on this trait use dense array operations instead
+fast_scalar_indexing(::CuArray) = false
 
 """
     upsample(a, stride)

--- a/src/yolo/nms.jl
+++ b/src/yolo/nms.jl
@@ -5,13 +5,19 @@ Compute IoU or Distance-IoU (DIoU) between a single bounding box `box1`
 and multiple boxes `box2`, writing results into `out`.
 
 - `box1`: A 4-element vector `[x1, y1, x2, y2]`
-- `box2`: A 4×N matrix, where each column is a bounding box
+- `box2`: A matrix with bounding box coordinates in rows 1:4, one box per column
 - `out`: A preallocated vector of length N for results
 - `distance`: if true, computes DIoU; otherwise standard IoU
 
+The 4-argument form compares `box1` against `box2[:, cols[i]]` for each `i`,
+allowing an index list to select columns without allocating a slice.
+
 Avoids allocations by reusing `out`.
 """
-function bboxiou!(out::AbstractArray{T}, box1, box2; distance::Bool=false, beta = T(0.6)) where T
+bboxiou!(out::AbstractArray{T}, box1, box2; kw...) where {T} =
+    bboxiou!(out, box1, box2, axes(box2, 2); kw...)
+
+function bboxiou!(out::AbstractArray{T}, box1, box2, cols::AbstractVector{<:Integer}; distance::Bool=false, beta = T(0.6)) where T
     b1x1, b1y1, b1x2, b1y2 = box1
     b1w = b1x2 - b1x1
     b1h = b1y2 - b1y1
@@ -21,10 +27,11 @@ function bboxiou!(out::AbstractArray{T}, box1, box2; distance::Bool=false, beta 
     b1cy = distance ? (b1y1 + b1y2) / 2 : zero(T)
 
     @inbounds for i in eachindex(out)
-        b2x1 = box2[1, i]
-        b2y1 = box2[2, i]
-        b2x2 = box2[3, i]
-        b2y2 = box2[4, i]
+        col = cols[i]
+        b2x1 = box2[1, col]
+        b2y1 = box2[2, col]
+        b2x2 = box2[3, col]
+        b2y2 = box2[4, col]
 
         # Intersection
         rectx1 = max(b1x1, b2x1)
@@ -117,12 +124,11 @@ function nms!(dets::AbstractArray{T}, iou_thresh; kind::Symbol = :default, beta:
         end
         b2_len = idx_len - 1
         b1 = @view dets[1:4, i]
-        b2s = @view dets[1:4, idxs[2:idx_len]]
 
         # Note that even diounms uses iou in inference. During training apparently it uses diou though.
         # That needs a further investigation though
         distance = kind in (:greedynms, :diounms)
-        bboxiou!(view(ious, 1:b2_len), b1, b2s; distance, beta)
+        bboxiou!(view(ious, 1:b2_len), b1, dets, view(idxs, 2:idx_len); distance, beta)
 
         write_idx = 0
         if kind in (:default, :greedynms, :diounms)
@@ -166,9 +172,10 @@ end
 """
     perform_detection_nms(batchout, overlap_thresh, batchsize; kind, beta, detect_thresh)
 
-For each batch `b` in `1:batchsize`, extract the detections from `batchout`,
-group them by class, sort each group by the end-2 column (class confidence score) descending, and
-run NMS to remove duplicates using bboxiou and overlap_thresh.
+Group the detections in `batchout` by batch and class, sort each group by the
+end-2 column (class confidence score) descending, and run NMS to remove
+duplicates using bboxiou and overlap_thresh. Returned detections are ordered
+by batch, then class id, then descending score.
 
 `detect_thresh` re-applies the caller's score threshold to the kept boxes.
 This only matters for `kind = :soft`, where scores are decayed during NMS and
@@ -189,46 +196,37 @@ batchout rows:
 - The last row is the batch index
 """
 function perform_detection_nms(batchout, overlap_thresh, batchsize::Int; kind::Symbol=:default, beta::Float32=0.6f0, detect_thresh::Float32=0f0)
+    nfields, N = size(batchout)
     output = similar(batchout)
+
+    # Order all detections once: by batch, then class, then descending score.
+    # Each (batch, class) group is then a contiguous, already-sorted column
+    # range of `sorted`, avoiding the previous per-batch/per-class scans and
+    # per-group sortperm+copy. sortperm is stable, so equal-score detections
+    # keep their original relative order.
+    perm = sortperm(1:N; by = i -> (@inbounds (batchout[end, i], batchout[end-1, i], -batchout[end-2, i])))
+    sorted = batchout[:, perm]
+
     i = 1  # index for writing into `output`
-
-    for b in 1:batchsize
-        b_cols = findall(==(b), @view(batchout[end, :]))
-        if isempty(b_cols)
-            continue
+    col = 1
+    @views while col <= N
+        b = sorted[end, col]
+        cls = sorted[end-1, col]
+        stop = col
+        @inbounds while stop < N && sorted[end, stop+1] == b && sorted[end-1, stop+1] == cls
+            stop += 1
         end
 
-        page = @view batchout[:, b_cols]
-        class_ids = @view page[end-1, :]
+        dets = sorted[:, col:stop] # a view: contiguous columns, scores descending
 
-        seen_classes = Set{eltype(class_ids)}()
+        keep = nms!(dets, overlap_thresh; kind, beta)
 
-        for (local_col_idx, cls) in enumerate(class_ids)
-            if cls in seen_classes
-                continue
-            end
-            push!(seen_classes, cls)
-
-            c_idxs = findall(==(cls), class_ids)
-            if isempty(c_idxs)
-                continue
-            end
-
-            dets = @view page[:, c_idxs]
-
-            scores = @view dets[end-2, :]
-            sorted_idx = sortperm(scores, rev=true)
-            # nms takes views of sorted_dets and copying here results in lower allocs and faster nms
-            sorted_dets = dets[:, sorted_idx]
-
-            keep = nms!(sorted_dets, overlap_thresh; kind, beta)
-
-            @inbounds for k in keep
-                sorted_dets[end-2, k] < detect_thresh && continue # soft-NMS may have decayed the score below threshold
-                output[:, i] = sorted_dets[:, k]
-                i += 1
-            end
+        for k in keep
+            dets[end-2, k] < detect_thresh && continue # soft-NMS may have decayed the score below threshold
+            output[:, i] .= dets[:, k]
+            i += 1
         end
+        col = stop + 1
     end
     return output[:, 1:i-1]
 end

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -752,12 +752,12 @@ function (yolo::Yolo)(img::T; detect_thresh=nothing, overlap_thresh=nothing, sho
                         delta = Float32(yolo.cfg[:output][outnr][:max_delta])
                         clamp!(weights[:, :, 1:2, :, :], -delta, delta)
                     end
-                    weights[:, :, 1:2, :, :] = (weights[:, :, 1:2, :, :] .* sxy .- (sxy - 1)/2 .+ out[:offset]) .* out[:scale]
-                    weights[:, :, 3:4, :, :] = (weights[:, :, 3:4, :, :] .* sxy).^2 .* out[:anchor]
+                    weights[:, :, 1:2, :, :] .= (weights[:, :, 1:2, :, :] .* sxy .- (sxy - 1)/2 .+ out[:offset]) .* out[:scale]
+                    weights[:, :, 3:4, :, :] .= (weights[:, :, 3:4, :, :] .* sxy).^2 .* out[:anchor]
                 else
                     # Classic behavior
-                    weights[:, :, 1:2, :, :] = (σ.(weights[:, :, 1:2, :, :]) .* sxy .- (sxy - 1)/2 .+ out[:offset]) .* out[:scale]
-                    weights[:, :, 3:4, :, :] = exp.(weights[:, :, 3:4, :, :]) .* out[:anchor]
+                    weights[:, :, 1:2, :, :] .= (σ.(weights[:, :, 1:2, :, :]) .* sxy .- (sxy - 1)/2 .+ out[:offset]) .* out[:scale]
+                    weights[:, :, 3:4, :, :] .= exp.(weights[:, :, 3:4, :, :]) .* out[:anchor]
                 end
 
                 if yolo.cfg[:laststage] === :region
@@ -765,7 +765,7 @@ function (yolo::Yolo)(img::T; detect_thresh=nothing, overlap_thresh=nothing, sho
                     # softmax over the class scores only when the cfg sets softmax=1;
                     # with softmax=0 darknet leaves the class scores linear
                     # (forward_region_layer)
-                    weights[:, :, 5, :, :] = σ.(weights[:, :, 5, :, :])
+                    weights[:, :, 5, :, :] .= σ.(weights[:, :, 5, :, :])
                     if get(yolo.cfg[:output][outnr], :softmax, 0) != 0
                         cls = weights[:, :, 6:end, :, :] # a view, via the enclosing @views
                         cls .= exp.(cls .- maximum(cls, dims=3))
@@ -774,31 +774,31 @@ function (yolo::Yolo)(img::T; detect_thresh=nothing, overlap_thresh=nothing, sho
                 elseif out[:final_conv_activation] != "logistic"
                     # Apply sigmoid to objectness (5) and class scores (6:a) ONLY if the
                     # preceding conv layer activation was NOT logistic (e.g., it was linear)
-                    weights[:, :, 5:end, :, :] = σ.(weights[:, :, 5:end, :, :])
+                    weights[:, :, 5:end, :, :] .= σ.(weights[:, :, 5:end, :, :])
                 end
 
                 if conf_fix
                     # post-sigmoid class confidence scores should be multiplied by the post-sigmoid box confidence score
                     # see https://github.com/openvinotoolkit/open_model_zoo/blob/master/models/public/yolo-v3-tiny-tf/README.md#original-model-1
-                    weights[:, :, 6:end, :, :] = weights[:, :, 6:end, :, :] .* weights[:, :, 5:5, :, :]
+                    weights[:, :, 6:end, :, :] .= weights[:, :, 6:end, :, :] .* weights[:, :, 5:5, :, :]
                 end
 
                 # Convert to image width & height scale (0.0-1.0)
-                weights[:, :, 1, :, :] = weights[:, :, 1, :, :] ./ size(img, 1) #x
-                weights[:, :, 2, :, :] = weights[:, :, 2, :, :] ./ size(img, 2) #y
+                weights[:, :, 1, :, :] .= weights[:, :, 1, :, :] ./ size(img, 1) #x
+                weights[:, :, 2, :, :] .= weights[:, :, 2, :, :] ./ size(img, 2) #y
                 if yolo.cfg[:laststage] === :region # indicates yolov2
                     cellsize_x, cellsize_y = (yolo.cfg[:width], yolo.cfg[:height]) ./ yolo.cfg[:gridsize]
-                    weights[:, :, 3, :, :] = (weights[:, :, 3, :, :] ./ size(img, 1)) * cellsize_x #w
-                    weights[:, :, 4, :, :] = (weights[:, :, 4, :, :] ./ size(img, 2)) * cellsize_y #h
+                    weights[:, :, 3, :, :] .= (weights[:, :, 3, :, :] ./ size(img, 1)) .* cellsize_x #w
+                    weights[:, :, 4, :, :] .= (weights[:, :, 4, :, :] ./ size(img, 2)) .* cellsize_y #h
                 else
-                    weights[:, :, 3, :, :] = (weights[:, :, 3, :, :] ./ size(img, 1)) #w
-                    weights[:, :, 4, :, :] = (weights[:, :, 4, :, :] ./ size(img, 2)) #h
+                    weights[:, :, 3, :, :] .= (weights[:, :, 3, :, :] ./ size(img, 1)) #w
+                    weights[:, :, 4, :, :] .= (weights[:, :, 4, :, :] ./ size(img, 2)) #h
                 end
 
-                weights[:, :, 1, :, :] = weights[:, :, 1, :, :] .- (weights[:, :, 3, :, :] .* 0.5) #x1
-                weights[:, :, 2, :, :] = weights[:, :, 2, :, :] .- (weights[:, :, 4, :, :] .* 0.5) #y1
-                weights[:, :, 3, :, :] = weights[:, :, 1, :, :] .+ weights[:, :, 3, :, :] #x2
-                weights[:, :, 4, :, :] = weights[:, :, 2, :, :] .+ weights[:, :, 4, :, :] #y2
+                weights[:, :, 1, :, :] .= weights[:, :, 1, :, :] .- (weights[:, :, 3, :, :] .* 0.5f0) #x1
+                weights[:, :, 2, :, :] .= weights[:, :, 2, :, :] .- (weights[:, :, 4, :, :] .* 0.5f0) #y1
+                weights[:, :, 3, :, :] .= weights[:, :, 1, :, :] .+ weights[:, :, 3, :, :] #x2
+                weights[:, :, 4, :, :] .= weights[:, :, 2, :, :] .+ weights[:, :, 4, :, :] #y2
 
                 # add 4 additional attributes for post-inference analysis. After findmax!
                 # below they hold: (unused), best class confidence (end-2),

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -700,6 +700,29 @@ function extend_for_attributes(weights::AbstractArray, w, h, bo, ba)
     return cat(weights, x, dims = 3)
 end
 
+fast_scalar_indexing(::AbstractArray) = true # CPU-resident arrays; overridden for CuArray in CUDAExt
+
+"""
+    flatten_with_attributes(weights, w, h, a, bo, ba)
+
+Permute a (w, h, a, bo, ba) output block to attribute-major order and append 4
+zero-initialized attribute rows, returning an (a+4, w*h*bo*ba) matrix.
+Equivalent to extend_for_attributes + permutedims + reshape, but with a single
+allocation on the CPU fast path.
+"""
+function flatten_with_attributes(weights::AbstractArray, w, h, a, bo, ba)
+    if fast_scalar_indexing(weights)
+        dst = similar(weights, Float32, a+4, w, h, bo, ba)
+        permutedims!(view(dst, 1:a, :, :, :, :), weights, (3, 1, 2, 4, 5))
+        fill!(view(dst, a+1:a+4, :, :, :, :), 0f0)
+        return reshape(dst, a+4, :)
+    else
+        # GPU path: dense cat + permutedims, avoiding scalar indexing
+        ext = extend_for_attributes(weights, w, h, bo, ba)
+        return reshape(permutedims(ext, (3, 1, 2, 4, 5)), a+4, :)
+    end
+end
+
 check_w_type(arr::AllocArray) = check_w_type(arr.arr)
 check_w_type(::UnsafeArray) = throw(ArgumentError("Internal error: UnsafeArray has leaked into internal buffer"))
 check_w_type(::Any) = nothing
@@ -803,11 +826,12 @@ function (yolo::Yolo)(img::T; detect_thresh=nothing, overlap_thresh=nothing, sho
                 # add 4 additional attributes for post-inference analysis. After findmax!
                 # below they hold: (unused), best class confidence (end-2),
                 # best class index (end-1), batch number (end)
-                weights = extend_for_attributes(weights, w, h, bo, ba)
+                weights = flatten_with_attributes(weights, w, h, a, bo, ba)
 
-                for batch in 1:ba weights[:, :, a+4, :, batch] .= batch end # write batchnumber to attribute a+4
-                weights = permutedims(weights, [3, 1, 2, 4, 5]) # place attributes first
-                weights = reshape(weights, a+4, :) # reshape to attr, data
+                npercol = w * h * bo # columns are ordered (w, h, bo, ba), so batches are contiguous
+                for batch in 1:ba
+                    weights[end, (batch-1)*npercol+1:batch*npercol] .= batch # write batchnumber to the last attribute row
+                end
 
                 detect_thresh = Float32(@something detect_thresh out[:truth_thresh])
                 findmax!(weights)

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -687,11 +687,47 @@ end
 
 """
     keepdetections(arr::AbstractArray)
+    keepdetections(outs::AbstractVector)
 
-Reduces the size of array and only keeps detections over threshold
+Reduces the size of array and only keeps detections over threshold.
+The vector form takes the per-output-head matrices and gathers the kept
+columns from all of them in one pass, without materializing their
+concatenation first.
 """
 function keepdetections(arr::AbstractArray)
     return arr[:, arr[end-2, :] .> 0]
+end
+
+function keepdetections(outs::AbstractVector)
+    if !all(fast_scalar_indexing, outs)
+        return keepdetections(cat(outs..., dims=2))
+    end
+    nfields = size(first(outs), 1)
+    n = sum(_count_kept, outs)
+    out = similar(first(outs), nfields, n)
+    i = 1
+    for o in outs
+        i = _copy_kept!(out, o, i)
+    end
+    return out
+end
+
+# function barriers: `outs` holds abstractly-typed elements
+function _count_kept(o::AbstractMatrix)
+    n = 0
+    @inbounds for j in axes(o, 2)
+        n += o[end-2, j] > 0f0
+    end
+    return n
+end
+function _copy_kept!(out::AbstractMatrix, o::AbstractMatrix, i::Int)
+    @inbounds for j in axes(o, 2)
+        if o[end-2, j] > 0f0
+            @views out[:, i] .= o[:, j]
+            i += 1
+        end
+    end
+    return i
 end
 
 function extend_for_attributes(weights::AbstractArray, w, h, bo, ba)
@@ -841,7 +877,7 @@ function (yolo::Yolo)(img::T; detect_thresh=nothing, overlap_thresh=nothing, sho
 
             # PROCESSING ALL PREDICTIONS
             ############################
-            @timeit to "filter detections" batchout = cpu(keepdetections(cat(outweights..., dims=2)))
+            @timeit to "filter detections" batchout = cpu(keepdetections(outweights))
 
             if size(batchout, 2) < 2
                 ret = batchout # empty or singular output doesn't need further filtering

--- a/src/yolo/yolo.jl
+++ b/src/yolo/yolo.jl
@@ -402,13 +402,17 @@ mutable struct Yolo <: AbstractModel
                     @error "Error reading weights for layer $cfg_idx of type $blocktype. Check the weights file." kern ch[end] filters pad stride act bn
                     rethrow()
                 end
+                if bn
+                    # Fold batchnorm into the conv weights and bias (as darknet's
+                    # fuse_conv_batchnorm does): at inference BN is the affine map
+                    # y -> (y - mean) / sqrt(var + eps) * scale + bias, which per
+                    # output channel folds exactly into the conv kernel and bias.
+                    # This removes a full read+write pass over every conv output.
+                    bnscale = bw ./ sqrt.(bv .+ 1f-5)
+                    cw = cw .* reshape(bnscale, 1, 1, 1, :)
+                    cb = bb .- bm .* bnscale
+                end
                 push!(stack, maybe_gpu(Flux.Conv(cw, cb; stride = stride, pad = pad, dilation = 1)))
-                # push!(stack, x -> begin
-                #     _out = maybe_gpu(Flux.Conv(cw, cb; stride=stride, pad=pad, dilation=1))(x)
-                #     @info "Layer conv $(size(x)) => $(size(_out))"
-                #     return _out
-                # end)
-                bn && push!(stack, maybe_gpu(Flux.BatchNorm(identity, bb, bw, bm, bv, 1f-5, 0.1f0, true, true, nothing, length(bb))))
                 push!(stack, _broadcast(act))
                 push!(fn, Flux.Chain(stack...))
                 push!(ch, filters)


### PR DESCRIPTION
> [!NOTE]
> This PR was written by Claude (Claude Code), from a performance review requested and supervised by @IanButterworth.

Follow-up to #131 (now merged; this branch has been rebased onto master). This PR reduces post-processing cost when many detections are kept — the stage that scales with detection count — and picks up the two forward-pass wins that survived measurement. Every commit was verified against the stored reference results for `v2_COCO`, `v2_tiny_COCO`, `v3_tiny_COCO` and `v3_COCO` (bit-identical for the post-processing commits; < 1e-6 for the batchnorm fold), plus the NMS unit tests and the soft-NMS fuzz check.

All numbers below were re-measured after the rebase, on current master vs this branch, same machine back-to-back (M2 Pro, CPU, single image, Julia 1.12, current deps incl. TimerOutputs v1).

## End-to-end benchmark

Typical settings (`detect_thresh=0.5`, `overlap_thresh=0.5`, default allocator, min of 15):

| Model | master | this PR | Δ |
|---|---|---|---|
| `v3_416_COCO` | 336.7 ms | 273.7 ms | **−19%** |
| `v3_tiny_416_COCO` | 41.5 ms | 32.9 ms | **−21%** |
| `v4_416_COCO` | 589.3 ms | 505.1 ms | **−14%** |

## Post-processing benchmark

Worst case: `v3_416_COCO` with **all 10,647 candidates kept** (`detect_thresh=0.0`, `overlap_thresh=1.0`, `disallow_bumper=true`), TimerOutputs stage breakdown (min of 5):

| Stage | master | this PR |
|---|---|---|
| processing outputs | 10.9 ms / 18.5 MiB | 11.0 ms / 5.4 MiB |
| filter detections | 730 µs / 9.1 MiB | 190 µs / 4.5 MiB |
| nms | 13.7 ms / 53.9 MiB | 11.4 ms / 14.2 MiB |
| **post-processing total** | **25.4 ms / 81.5 MiB** | **22.7 ms / 24.1 MiB** |

The 3.4× allocation reduction is the headline for dense scenes: in continuous-inference loops, post-processing GC pressure compounds.

## Post-processing commits

1. **Fuse post-processing broadcasts in place** — the ~17 per-head transform statements were `view[...] = RHS`, each materializing the RHS array before copying; `.=` fuses them into single passes.
2. **Restructure NMS: single global sort, allocation-free IoU indexing** — the big one, two parts:
   - `perform_detection_nms` scanned all columns per batch (`findall`), then per distinct class (`Set` + `findall`), then ran a per-group `sortperm` + matrix copy through nested index-vector views. Now one stable `sortperm` by (batch, class, −score) plus one gather makes every (batch, class) group a contiguous, already-sorted column range.
   - `nms!` allocated an index slice per suppression round to build its IoU view — O(N²) bytes per group, the bulk of the old 54 MiB. `bboxiou!` gained a column-index variant so rounds read through a view of the persistent index vector with zero per-round allocation.
   - ⚠️ One visible change (also in the CHANGELOG): output columns are now ordered by batch, then **ascending class id**, then descending score; classes were previously in first-appearance order. Within-class ordering is unchanged (stable sort).
3. **Flatten output blocks to attribute-major with a single allocation** — `extend_for_attributes` (zeros + `cat`) followed by `permutedims` copied each head's data three times; now a single `permutedims!` writes straight into the first `a` rows of the final (a+4)-row buffer. GPU arrays keep the dense cat+permutedims path via a new `fast_scalar_indexing` trait (CUDAExt sets it `false` for `CuArray`).
4. **Gather kept detections without materializing the concatenation** — `keepdetections` needed `cat(outweights...)` plus a boolean-mask gather (two full copies); a new vector method counts and copies kept columns directly from the per-head matrices, with function barriers keeping the loops concretely typed. GPU falls back to the cat path via the same trait.

## Forward pass

Measurement first (v3_416, CPU): the pass is **gemm-bound, not allocation-bound** — the default bumper path already recycles the ~890 MiB of forward allocations down to ~260 KiB with no time change, Julia threads do nothing (conv threading is BLAS-side: 1 BLAS thread = 842 ms, 6 = 317 ms), and **AppleAccelerate drops v3_416 from ~317 ms to ~207 ms (−35%) with zero code changes**. Two commits follow from this:

5. **Fold batchnorm into conv weights at load time** (darknet's `fuse_conv_batchnorm`) — BN at inference is a per-channel affine map, so it folds exactly into the kernel and bias, deleting the BatchNorm pass over every conv output. This is the bulk of the end-to-end wins in the first table. Max abs deviation vs stored refs < 1e-6, so no reference updates. Side benefit: the positional `Flux.BatchNorm` internal constructor — a compat hazard across Flux versions flagged in the original review — is no longer used.
6. **README: CPU performance tips** — AppleAccelerate on Apple silicon (~35%), MKL on Intel, BLAS threads as the parallelism knob, and batching for throughput.

## Considered and deliberately not done

- The remaining ~11 ms in "processing outputs" is real compute (~900k sigmoid/exp evaluations); faster approximations would change numerics.
- The O(n²) IoU work when nothing gets suppressed is inherent to hard NMS at `overlap_thresh=1.0`; at realistic thresholds the loop shrinks as boxes are culled.
- In-place `conv!` into the preallocated `W` buffers: mostly moot since the pass isn't allocation-bound.
- A Metal.jl backend for Apple silicon is the big structural option (GPU-class speedup) but needs its own extension work — the post-processing kernels are CUDA-specific today.

## Caveats

- The GPU fallback paths (trait-gated) are review-verified but untested on CUDA hardware, same as #131. The batchnorm fold applies before weights move to the GPU, so the CUDA path gets it too (and one less layer per conv block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
