### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## v1.2.0 - 2026-08-07
+
+Deep review series: #131 (bugfixes), #132 (performance), #137 (new models), #138 (quality).
 
 ### New models
 - Add the Scaled-YOLOv4 family and yolov7x, all with official COCO weights:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ObjectDetector"
 uuid = "3dfc1049-5314-49cf-8447-288dfd02f9fb"
-version = "1.1.2"
+version = "1.2.0"
 authors = ["Robert Luciani"]
 
 [workspace]


### PR DESCRIPTION
> [!NOTE]
> This PR was written by Claude (Claude Code), requested and supervised by @IanButterworth.

Version bump to **v1.2.0** and changelog date, covering the deep-review series: #131 (bugfixes), #132 (performance), #137 (new models), #138 (quality).

## Why minor, not breaking

Reviewed against semver:
- Existing pretrained constructors keep their 416 default; only the six new models get native-size defaults.
- The NMS output-column ordering change (ascending class id vs first-appearance) and `benchmark()` requiring `using BenchmarkTools, PrettyTables` are behavior changes in unexported/undocumented-contract areas, called out in the changelog.
- Removed symbols (`flipdict`, `createcountdict`, `lhtan_grad`, `nms` → `nms!`) were all unexported.
- Flux compat narrowing is a constraint tightening, not an API change.
